### PR TITLE
partitions: Use ≥ for min partition size

### DIFF
--- a/src/ui/pages/partitions.rs
+++ b/src/ui/pages/partitions.rs
@@ -549,9 +549,9 @@ impl FactoryComponent for WholeDisk {
             #[watch]
             // Translators: Do NOT translate the '{}'
             // The string reads "{/dev/sdX} (20 GB minimum needed)" indicating that the given disk is not large enough
-            set_subtitle: &if self.size > 21_474_836_480  { size::Size::from_bytes(self.size).to_string() } else { i18n_f("{} (20 GB minimum needed)", &[&size::Size::from_bytes(self.size).to_string()]) },
+            set_subtitle: &if self.size >= 21_474_836_480  { size::Size::from_bytes(self.size).to_string() } else { i18n_f("{} (20 GB minimum needed)", &[&size::Size::from_bytes(self.size).to_string()]) },
             set_activatable: true,
-            set_sensitive: self.size > 21_474_836_480, // 20GB
+            set_sensitive: self.size >= 21_474_836_480, // 20GB
             #[name(checkbtn)]
             add_suffix = &gtk::CheckButton {
                 set_group: Some(&self.group),


### PR DESCRIPTION
Otherwise, we will be unable to install it in GNOME Boxes with the default NixOS hardware preset of 20 GiB.

![Partition selector does not want to allow choosing 20 GiB virtual drive](https://github.com/snowfallorg/icicle/assets/705123/0955c860-5a2a-4572-8eb1-d346bb218f0e)
